### PR TITLE
fix insert of concurrent_unordered_map

### DIFF
--- a/HugeCTR/include/hashtable/cudf/concurrent_unordered_map.cuh
+++ b/HugeCTR/include/hashtable/cudf/concurrent_unordered_map.cuh
@@ -495,6 +495,7 @@ class concurrent_unordered_map : public managed {
         update_existing_value(existing_value, x, op);
 
         insert_success = true;
+        break;
       }
 
       current_index = (current_index + 1) % hashtbl_size;


### PR DESCRIPTION
I find a bug of concurrent_unordered_map, when insert,  the iterator it returns should be pointed to the inserted element, not its next element.

thanks for your review.