### PR TITLE
【BUG】two different table use same param_interface

### DIFF
--- a/sparse_operation_kit/kit_cc/kit_cc_infra/src/parameters/raw_manager.cc
+++ b/sparse_operation_kit/kit_cc/kit_cc_infra/src/parameters/raw_manager.cc
@@ -88,6 +88,9 @@ void RawManager::create_variables(const size_t local_replica_id, const std::stri
   if (shape == previous_shape) {
     // return the previous param
     param = previous_param;
+    
+    // reset previoud_shape for the case that two different table use same param
+    previous_param = std::vector<size_t>();
   } else {
     std::shared_ptr<RawParam> raw_param{nullptr};
     {  // begin write


### PR DESCRIPTION
when using two different table with the same vocabulary_size and the same embedding_vec_size, this bug could happen.