### PR TITLE
fixed the error img url link in performace.md

### DIFF
--- a/performance.md
+++ b/performance.md
@@ -10,7 +10,7 @@ We've tested HugeCTR's performance on the following systems:
 ## MLPerf on DGX-2 and DGX A100
 The DLRM benchmark was submitted to [MLPerf Training v0.7](https://mlperf.org/training-results-0-7) with the release of HugeCTR version 2.2 and [MLPerf Training v1.0](https://mlcommons.org/en/news/mlperf-training-v10) with the release of HugeCTR version 3.1. We used the [Criteo 1TB Click Logs dataset](https://labs.criteo.com/2013/12/download-terabyte-click-logs/), which contains 4 billion user and item interactions over 24 days. The DGX-2 with 16 V100 GPUs and DGX A100 with eight A100 GPUs were the target machines. For more information, see [this blog post](https://developer.nvidia.com/blog/optimizing-ai-performance-for-mlperf-v0-7-training/).
 
-<div align=center><img width = '600' height ='400' src ="docs/user_guide_src/mlperf_10.PNG"/></div>
+<div align=center><img width = '600' height ='400' src ="docs/source/user_guide_src/mlperf_10.PNG"/></div>
 <div align=center>Fig. 1: HugeCTR's MLPerf v1.0 Result</div>
 
 ## Evaluating HugeCTR's Performance on the DGX-1
@@ -35,16 +35,16 @@ Preprocessing:
 
 The scalability of HugeCTR and the number of active GPUs have increased simply because of the high-efficient data exchange and three-stage processing pipeline. In this pipeline, we overlap the data reading from the file, host to the device data transaction (inter-node and intra-node), and train the GPU. The following chart shows the scalability of HugeCTR with a batch size of 16384 and seven layers on DGX1 servers.
 
-<div align=center><img width = '800' height ='400' src ="docs/user_guide_src/fig12_multi_gpu_performance.PNG"/></div>
+<div align=center><img width = '800' height ='400' src ="docs/source/user_guide_srcfig12_multi_gpu_performance.PNG"/></div>
 <div align=center>Fig. 2: HugeCTR's Multi-GPU Performance</div>
 
 ## Evaluating HugeCTR's Performance on TensorFlow
 In the TensorFlow test case that's shown here, HugeCTR exhibits a speedup up to 114 times faster compared to a CPU server running TensorFlow with only one V100 GPU and almost the same loss curve.
 
-<div align=center><img width = '800' height ='400' src ="docs/user_guide_src/WDL.JPG"/></div>
+<div align=center><img width = '800' height ='400' src ="docs/source/user_guide_srcWDL.JPG"/></div>
 <div align=center>Fig. 3: WDL Performance and Loss Curve Comparison with TensorFlow Version 2.0</div>
 
 <br></br>
 
-<div align=center><img width = '800' height ='400' src ="docs/user_guide_src/DCN.JPG"/></div>
+<div align=center><img width = '800' height ='400' src ="docs/source/user_guide_srcDCN.JPG"/></div>
 <div align=center>Fig. 4: DCN performance and Loss Curve Comparison with TensorFlow Version 2.0</div>


### PR DESCRIPTION
The image link in https://github.com/NVIDIA-Merlin/HugeCTR/blob/master/performance.md is error
![截屏2022-06-23 17 40 33](https://user-images.githubusercontent.com/1612381/175269096-8bffd0ab-eea3-46c8-9010-63f1f8bdb383.png)
.