### PR TITLE
Remove unnecessary deps from docs build

### DIFF
--- a/docs/requirements-doc.txt
+++ b/docs/requirements-doc.txt
@@ -7,14 +7,12 @@ wheel
 Sphinx<3.6
 jinja2<3.1
 markupsafe==2.0.1
-sphinx_markdown_tables==0.0.15
 sphinx-multiversion@git+https://github.com/mikemckiernan/sphinx-multiversion.git
 sphinxcontrib-copydirs@git+https://github.com/mikemckiernan/sphinxcontrib-copydirs.git
 sphinx-external-toc<0.4
 sphinx_rtd_theme
-recommonmark>=0.6
 natsort<8.2
-myst-nb<0.14
-markdown-it-py<1.2
-linkify-it-py<1.1
+myst-nb
+markdown-it-py
+linkify-it-py
 

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -52,7 +52,6 @@ extensions = [
     "myst_nb",
     "sphinx_external_toc",
     "sphinx_rtd_theme",
-    "sphinx_markdown_tables",
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
@@ -76,7 +75,7 @@ myst_enable_extensions = [
 ]
 myst_linkify_fuzzy_links = False
 myst_heading_anchors = 4
-jupyter_execute_notebooks = "off"
+nb_execution_mode = "off"
 
 # Some documents are RST and include `.. toctree::` directives.
 suppress_warnings = ["etoc.toctree", "myst.header", "misc.highlighting_failure"]

--- a/notebooks/training_with_hdfs.ipynb
+++ b/notebooks/training_with_hdfs.ipynb
@@ -204,11 +204,7 @@
    "source": [
     "## Wide and Deep Model\n",
     "\n",
-<<<<<<< HEAD
     "In the Docker container, `nvcr.io/nvidia/merlin/merlin-hugectr:22.07`, \n",
-=======
-    "In the Docker container, `nvcr.io/nvidia/merlin/merlin-hugectr:22.06`, \n",
->>>>>>> master
     "make sure that you installed Hadoop and set the proper environment variables as instructed in the preceding sections.\n",
     "\n",
     "If you chose to compile HugeCTR, make sure you that you set `DENABLE_HDFS` to `ON`.\n",


### PR DESCRIPTION
The sphinx_markdown_tables module isn't used.

One tweak to the training with HDFS notebook so that it can build.