### PR TITLE
fix: typo in kafka broker

### DIFF
--- a/HugeCTR/include/pybind/solver_wrapper.hpp
+++ b/HugeCTR/include/pybind/solver_wrapper.hpp
@@ -146,7 +146,7 @@ void SolverPybind(pybind11::module& m) {
         pybind11::arg("all_reduce_algo") = AllReduceAlgo::NCCL,
         pybind11::arg("grouped_all_reduce") = false,
         pybind11::arg("num_iterations_statistics") = 20, pybind11::arg("perf_logging") = false,
-        pybind11::arg("drop_incomplete_batch") = true, pybind11::arg("kafka_brockers") = "",
+        pybind11::arg("drop_incomplete_batch") = true, pybind11::arg("kafka_brokers") = "",
         pybind11::arg("training_callbacks") = std::vector<std::shared_ptr<TrainingCallback>>());
 }
 


### PR DESCRIPTION
While reviewing the [WeChat article](https://mp.weixin.qq.com/s/5_AKe6f_nJjddCLZU28P2A), I came across a subtle typographical error within the parameters of `CreateSolver` interface, where **`kafka_brokers` was mistakenly referred to as `kafka_brockers`**. Considering that this minor oversight could lead to potential confusion or implementation issues, I believe it is imperative to correct this.