### PR TITLE
Fix `TypeError` by specifying a  `check_type` argument in `DataReaderParams`.

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ If you'd like to quickly train a model using the Python interface, do the follow
    reader = hugectr.DataReaderParams(data_reader_type = hugectr.DataReaderType_t.Parquet,
                                     source = ["./dcn_parquet/file_list.txt"],
                                     eval_source = "./dcn_parquet/file_list_test.txt",
-                                    check_type = hugectr.Check_t.Non
+                                    check_type = hugectr.Check_t.Non,
                                     slot_size_array = [39884, 39043, 17289, 7420, 20263, 3, 7120, 1543, 39884, 39043, 17289, 7420, 
                                                       20263, 3, 7120, 1543, 63, 63, 39884, 39043, 17289, 7420, 20263, 3, 7120, 1543 ])
    optimizer = hugectr.CreateOptimizer(optimizer_type = hugectr.Optimizer_t.Adam,

--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ If you'd like to quickly train a model using the Python interface, do the follow
    reader = hugectr.DataReaderParams(data_reader_type = hugectr.DataReaderType_t.Parquet,
                                     source = ["./dcn_parquet/file_list.txt"],
                                     eval_source = "./dcn_parquet/file_list_test.txt",
+                                    check_type = hugectr.Check_t.Non
                                     slot_size_array = [39884, 39043, 17289, 7420, 20263, 3, 7120, 1543, 39884, 39043, 17289, 7420, 
                                                       20263, 3, 7120, 1543, 63, 63, 39884, 39043, 17289, 7420, 20263, 3, 7120, 1543 ])
    optimizer = hugectr.CreateOptimizer(optimizer_type = hugectr.Optimizer_t.Adam,


### PR DESCRIPTION
This PR fixes a `TypeError` in the example training script by specifying a check_type argument (i.e., `hugectr.Check_t.Non`) in the `hugectr.DataReaderParams` constructor. 

Based on the [API documentation](https://nvidia-merlin.github.io/HugeCTR/main/api/python_interface.html#:~:text=check_type%3A%20The%20data%20error%20detection%20mechanism.%20Specify%20hugectr.Check_t.Sum%20(CheckSum)%20or%20hugectr.Check_t.Non%20(no%20detection).%20This%20argument%20has%20no%20default%20value%20and%20you%20must%20specify%20a%20value), the `check_type` argument has no default value and a value must be specified.